### PR TITLE
chore: add CODEOWNERS for ml-platform team

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,1 +1,1 @@
-* @patterninc/ml-platform
+# Invalid location for CODEOWNERS; move this rule to `.github/CODEOWNERS` and remove this file.

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,1 @@
+* @patterninc/ml-platform


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/CODEOWNERS` assigning `@patterninc/ml-platform` as owners of all files in the repo

## Test plan
- [ ] Verify that PRs automatically request review from `@patterninc/ml-platform`

🤖 Generated with [Claude Code](https://claude.com/claude-code)