### PR TITLE
fix: set Snowflake warehouse via USE WAREHOUSE query

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ds-platform-utils"
-version = "0.4.1"
+version = "0.4.2"
 description = "Utility library for Pattern Data Science."
 readme = "README.md"
 authors = [

--- a/src/ds_platform_utils/metaflow/snowflake_connection.py
+++ b/src/ds_platform_utils/metaflow/snowflake_connection.py
@@ -80,10 +80,12 @@ def _create_snowflake_connection(
     conn: SnowflakeConnection = Snowflake(
         integration=SNOWFLAKE_INTEGRATION,
         client_session_keep_alive=True,
-        warehouse=warehouse,
         timezone="UTC" if use_utc else None,
         session_parameters={"QUERY_TAG": query_tag},
     ).cn  # type: ignore[attr-defined]
+
+    ## Doing this in the connection parameters result in silently failing to set the warehouse, so we have to execute a raw query to set it.
+    conn.execute_string("USE WAREHOUSE {}".format(warehouse)) 
 
     return conn
 

--- a/src/ds_platform_utils/metaflow/snowflake_connection.py
+++ b/src/ds_platform_utils/metaflow/snowflake_connection.py
@@ -84,7 +84,7 @@ def _create_snowflake_connection(
         session_parameters={"QUERY_TAG": query_tag},
     ).cn  # type: ignore[attr-defined]
 
-    # Doing this in the connection parameters result in silently failing to set the warehouse, 
+    # Doing this in the connection parameters result in silently failing to set the warehouse,
     # so we have to execute a raw query to set it.
     conn.execute_string("USE WAREHOUSE {}".format(warehouse))
 

--- a/src/ds_platform_utils/metaflow/snowflake_connection.py
+++ b/src/ds_platform_utils/metaflow/snowflake_connection.py
@@ -84,8 +84,9 @@ def _create_snowflake_connection(
         session_parameters={"QUERY_TAG": query_tag},
     ).cn  # type: ignore[attr-defined]
 
-    ## Doing this in the connection parameters result in silently failing to set the warehouse, so we have to execute a raw query to set it.
-    conn.execute_string("USE WAREHOUSE {}".format(warehouse)) 
+    # Doing this in the connection parameters result in silently failing to set the warehouse, 
+    # so we have to execute a raw query to set it.
+    conn.execute_string("USE WAREHOUSE {}".format(warehouse))
 
     return conn
 

--- a/uv.lock
+++ b/uv.lock
@@ -479,7 +479,7 @@ wheels = [
 
 [[package]]
 name = "ds-platform-utils"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary
- Passing `warehouse` as a Snowflake connection parameter silently fails to set it — the warehouse was never actually being applied
- Fixed by executing `USE WAREHOUSE <name>` as a raw SQL query after the connection is established
- Bumps version to `0.4.2`

## Test plan
- [x] Verify Snowflake queries run against the correct warehouse after the connection is created
- [x] Confirm no regression in existing Snowflake connection flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)